### PR TITLE
improved tweet formatter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,6 @@ linters:
     - structcheck
     - gas
     - gocyclo
-    - dupl
     - misspell
     - unparam
     - varcheck


### PR DESCRIPTION
This PR adds some smartness around twitter links in an attempt to prevent unneeded trimming.
Basically, it understands if `{{.Text}}` or `{{.Title}}` should be trimmed and does it in a less brutal way.

should address #11 